### PR TITLE
Add `Get Status` to Device Command menu

### DIFF
--- a/govee/api/lan/status.py
+++ b/govee/api/lan/status.py
@@ -63,10 +63,9 @@ def get_device_status(
     sock = None
     try:
         # Create UDP socket and bind to ephemeral port for responses
-        # Using port 0 lets OS assign an available port, avoiding conflicts in parallel queries
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind(('0.0.0.0', 0))  # OS assigns ephemeral port (avoids "Address already in use")
+        sock.bind(('', listen_port))
         sock.settimeout(timeout)
 
         # Convert payload to JSON bytes

--- a/govee/cli.py
+++ b/govee/cli.py
@@ -16,6 +16,7 @@ from typing import Optional, List, Dict, Any
 
 from govee.client import GoveeClient
 from govee.models import Device, Scene, DIYScene, MusicMode, Colors
+from govee.exceptions import GoveeLANNotSupportedError
 from govee import __version__
 
 # Config file location
@@ -318,7 +319,8 @@ def device_commands_menu(client: GoveeClient):
             "Set Scene",
             "Set DIY Scene",
             "Set Music Mode",
-            "Get State"
+            "Get State",
+            "Get Status [LAN Only]",
         ]
 
         choice = print_menu(options)
@@ -361,6 +363,9 @@ def device_commands_menu(client: GoveeClient):
 
         elif choice == 9:  # Get State
             get_device_state(client, device)
+
+        elif choice == 10:  # Get Status [LAN Only]
+            get_device_status(client, device)
 
 
 def set_color_submenu(client: GoveeClient, device: Device):
@@ -576,6 +581,15 @@ def get_device_state(client: GoveeClient, device: Device):
     """Get the device state"""
     state = client.get_device_state(device)
     print(json.dumps(state, indent=4))
+
+
+def get_device_status(client: GoveeClient, device: Device):
+    """Get the device status (LAN only)"""
+    try:
+        status = client.get_device_status(device)
+        print(json.dumps(status, indent=4))
+    except GoveeLANNotSupportedError:
+        print("Not a LAN device")
 
 
 def main_menu():

--- a/govee/client.py
+++ b/govee/client.py
@@ -18,6 +18,7 @@ from govee.exceptions import (
     GoveeDeviceNotFoundError,
     GoveeSceneNotFoundError,
     GoveeInvalidParameterError,
+    GoveeLANNotSupportedError
 )
 from govee.api.cloud import devices as cloud_devices
 from govee.api.cloud import device_control as cloud_control
@@ -29,6 +30,7 @@ from govee.api.lan import power as lan_power
 from govee.api.lan import brightness as lan_brightness
 from govee.api.lan import color as lan_color
 from govee.api.lan import discovery as lan_discovery
+from govee.api.lan import status as lan_status
 
 logger = logging.getLogger(__name__)
 
@@ -1993,3 +1995,20 @@ class GoveeClient:
             Device state
         """
         return device_state.get_device_state(self.api_key, device_id=device.id, sku=device.sku)
+
+    def get_device_status(self, device: Device):
+        """
+        Get the device's status
+
+        Args:
+            device: device to query
+
+        Returns:
+            Device status
+
+        Raises:
+            GoveeLANNotSupportedError: If not a LAN device
+        """
+        if device.supports_lan:
+            return lan_status.get_device_status(device.ip)
+        raise GoveeLANNotSupportedError(device_name=device.name)


### PR DESCRIPTION
This PR adds the ability to query the status of a device via the LAN API.

It also fixes a bug in api.lan.status::get_device_status where we weren't binding to the listen port thus not getting the response.